### PR TITLE
Allow trac-slack-plugin able to be run on Python 3

### DIFF
--- a/slack_notification/ticket.py
+++ b/slack_notification/ticket.py
@@ -8,12 +8,12 @@ from trac.ticket.api import ITicketChangeListener
 
 def prepare_ticket_values(ticket, action=None):
         values = ticket.values.copy()
-        values['id'] = u"#" + unicode(ticket.id)
+        values['id'] = "#" + str(ticket.id)
         values['action'] = action
         values['url'] = ticket.env.abs_href.ticket(ticket.id)
         values['project'] = ticket.env.project_name.strip()
-        values['attrib'] = u''
-        values['changes'] = u''
+        values['attrib'] = ''
+        values['changes'] = ''
         return values
 
 class SlackNotifcationPlugin(Component):
@@ -29,28 +29,28 @@ class SlackNotifcationPlugin(Component):
 
         def notify(self, type, values):
                 # values['type'] = type
-                values['author'] = re.sub(r' <.*', u'', values['author'])
+                values['author'] = re.sub(r' <.*', '', values['author'])
                 #template = u'%(project)s/%(branch)s %(rev)s %(author)s: %(logmsg)s'
                 #template = u'%(project)s %(rev)s %(author)s: %(logmsg)s'
-                template = u'_%(project)s_ :incoming_envelope: \n%(type)s <%(url)s|%(id)s>: %(summary)s [*%(action)s* by @%(author)s]'
+                template = '_%(project)s_ :incoming_envelope: \n%(type)s <%(url)s|%(id)s>: %(summary)s [*%(action)s* by @%(author)s]'
 
                 attachments = []
 
-                if values['action'] == u'closed':
-                        template += u' :white_check_mark:'
+                if values['action'] == 'closed':
+                        template += ' :white_check_mark:'
 
-                if values['action'] == u'created':
-                        template += u' :pushpin:'
+                if values['action'] == 'created':
+                        template += ' :pushpin:'
 
                 if values['attrib']:
                         attachments.append({
-                                'title': u'Attributes',
+                                'title': 'Attributes',
                                 'text': values['attrib']
                         })
 
                 if values.get('changes', False):
                         attachments.append({
-                                'title': u':small_red_triangle: Changes',
+                                'title': ':small_red_triangle: Changes',
                                 'text': values['changes']
                         })
 
@@ -60,14 +60,14 @@ class SlackNotifcationPlugin(Component):
 
                 if values['description']:
                         attachments.append({
-                                'title': u'Description',
-                                'text': re.sub(r'({{{|}}})', u'', values['description'])
+                                'title': 'Description',
+                                'text': re.sub(r'({{{|}}})', '', values['description'])
                         })
 
                 if values['comment']:
                         attachments.append({
-                                'title': u'Comment:',
-                                'text': re.sub(r'({{{|}}})', u'', values['comment'])
+                                'title': 'Comment:',
+                                'text': re.sub(r'({{{|}}})', '', values['comment'])
                         })
 
                 message = template % values
@@ -85,51 +85,51 @@ class SlackNotifcationPlugin(Component):
                 return True
 
         def ticket_created(self, ticket):
-                values = prepare_ticket_values(ticket, u'created')
+                values = prepare_ticket_values(ticket, 'created')
                 values['author'] = values['reporter']
-                values['comment'] = u''
+                values['comment'] = ''
                 fields = self.fields.split(',')
                 attrib = []
 
                 for field in fields:
-                        if ticket[field] != u'':
-                                attrib.append(u'\u2022 %s: %s' % (field, ticket[field]))
+                        if ticket[field] != '':
+                                attrib.append('\u2022 %s: %s' % (field, ticket[field]))
 
-                values['attrib'] = u"\n".join(attrib) or u''
+                values['attrib'] = "\n".join(attrib) or ''
 
-                self.notify(u'ticket', values)
+                self.notify('ticket', values)
 
         def ticket_changed(self, ticket, comment, author, old_values):
-                action = u'changed'
+                action = 'changed'
                 if 'status' in old_values:
                         if 'status' in ticket.values:
                                 if ticket.values['status'] != old_values['status']:
                                         action = ticket.values['status']
                 values = prepare_ticket_values(ticket, action)
                 values.update({
-                        'comment': comment or u'',
-                        'author': author or u'',
+                        'comment': comment or '',
+                        'author': author or '',
                         'old_values': old_values
                 })
 
-                if 'description' not in old_values.keys():
-                        values['description'] = u''
+                if 'description' not in list(old_values.keys()):
+                        values['description'] = ''
 
                 fields = self.fields.split(',')
                 changes = []
                 attrib = []
 
                 for field in fields:
-                        if ticket[field] != u'':
-                                attrib.append(u'\u2022 %s: %s' % (field, ticket[field]))
+                        if ticket[field] != '':
+                                attrib.append('\u2022 %s: %s' % (field, ticket[field]))
 
-                        if field in old_values.keys():
-                                changes.append(u'\u2022 %s: %s \u2192 %s' % (field, old_values[field], ticket[field]))
+                        if field in list(old_values.keys()):
+                                changes.append('\u2022 %s: %s \u2192 %s' % (field, old_values[field], ticket[field]))
 
-                values['attrib'] = u"\n".join(attrib) or u''
-                values['changes'] = u"\n".join(changes) or u''
+                values['attrib'] = "\n".join(attrib) or ''
+                values['changes'] = "\n".join(changes) or ''
 
-                self.notify(u'ticket', values)
+                self.notify('ticket', values)
 
         def ticket_deleted(self, ticket):
                 pass

--- a/slack_notification/ticket.py
+++ b/slack_notification/ticket.py
@@ -75,7 +75,7 @@ class SlackNotifcationPlugin(Component):
                 data = {
                         "channel": self.channel,
                         "username": self.username,
-                        "text": message.encode('utf-8').strip(),
+                        "text": message.strip(),
                         "attachments": attachments
                 }
                 try:


### PR DESCRIPTION
Just some simple changes:

* Use 2to3 to fix some unicode related codes.
* Avoid from utf-8 translation in Python 3, since it's already an unicode-based environment.

Tested on my own Trac instance (Trac 1.6 w/ Python 3.11 on Ubuntu 22.04).

I know this repository is not active for a long time, but since Trac 1.6 was released and it's the first version to support Python 3, I would like to send a PR to support it.

Hope everyone has a nice day :-)